### PR TITLE
Issue 15: Compatibility with new version of apt cookbook

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -99,8 +99,8 @@ when "ubuntu", "debian"
 
     apt_repository "jenkins" do
       uri "http://pkg.jenkins-ci.org/debian"
-      distribution node['lsb']['codename']
-      components ["binary"]
+      distribution "binary/"
+      components [""]
       key = "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
       action :add
     end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -101,7 +101,7 @@ when "ubuntu", "debian"
       uri "http://pkg.jenkins-ci.org/debian"
       distribution "binary/"
       components [""]
-      key = "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
+      key "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
       action :add
     end
   end


### PR DESCRIPTION
This adds compatibility for the version of the apt cookbook currently in the opscode repo. I'm not 100% sure on the debian implementation though, as it's possible that could be improved. I'm using this with Ubuntu though
