### PR TITLE
Debian/ubuntu work the same (at least with squeeze)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,39 +82,15 @@ case node.platform
 when "ubuntu", "debian"
   # See http://jenkins-ci.org/debian/
 
-  case node.platform
-  when "debian"
-    remote = "#{node[:jenkins][:mirror]}/latest/debian/jenkins.deb"
-    package_provider = Chef::Provider::Package::Dpkg
+  include_recipe "apt"
+  include_recipe "java"
 
-    package "daemon"
-    # These are both dependencies of the jenkins deb package
-    package "jamvm"
-    package "openjdk-6-jre"
-
-    package "psmisc"
-    key_url = "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
-
-    remote_file "#{tmp}/jenkins-ci.org.key" do
-      source "#{key_url}"
-    end
-
-    execute "add-jenkins-key" do
-      command "apt-key add #{tmp}/jenkins-ci.org.key"
-      action :nothing
-    end
-
-  when "ubuntu"
-    include_recipe "apt"
-    include_recipe "java"
-
-    apt_repository "jenkins" do
-      uri "http://pkg.jenkins-ci.org/debian"
-      distribution "binary/"
-      components [""]
-      key "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
-      action :add
-    end
+  apt_repository "jenkins" do
+    uri "http://pkg.jenkins-ci.org/debian"
+    distribution "binary/"
+    components [""]
+    key "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
+    action :add
   end
 
   pid_file = "/var/run/jenkins/jenkins.pid"


### PR DESCRIPTION
There is no need to do something different from Ubuntu with Debian. And jamvm is no more available on Debian Squeeze (stable). The standard java is openjdk, as on Ubuntu
