### PR TITLE
Manage /etc/default/jenkins with a template

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -69,7 +69,7 @@ Where the jenkins_login recipe is simply:
 * jenkins[:http_proxy][:host_name] - primary vhost name for the HTTP proxy to respond to (`node[:fqdn]` by default)
 * jenkins[:http_proxy][:host_aliases] - optional list of other host aliases to respond to (empty by default)
 * jenkins[:http_proxy][:client_max_body_size] - max client upload size ("1024m" by default, nginx only)
-* jenkins[:http_proxy][:prefix] - HTTP server URL path proxy prefix (`nil` by default)
+* jenkins[:http_proxy][:prefix] - HTTP server URL path proxy prefix ("/" by default)
 
 = USAGE:
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -69,6 +69,7 @@ Where the jenkins_login recipe is simply:
 * jenkins[:http_proxy][:host_name] - primary vhost name for the HTTP proxy to respond to (`node[:fqdn]` by default)
 * jenkins[:http_proxy][:host_aliases] - optional list of other host aliases to respond to (empty by default)
 * jenkins[:http_proxy][:client_max_body_size] - max client upload size ("1024m" by default, nginx only)
+* jenkins[:http_proxy][:prefix] - HTTP server URL path proxy prefix (`nil` by default)
 
 = USAGE:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,9 +34,22 @@ else
   default[:jenkins][:server][:group] = node[:jenkins][:server][:user]
 end
 
+# HTTP Proxy
+default[:jenkins][:http_proxy][:variant]              = nil
+default[:jenkins][:http_proxy][:www_redirect]         = "disable"
+default[:jenkins][:http_proxy][:listen_ports]         = [ 80 ]
+default[:jenkins][:http_proxy][:host_name]            = nil
+default[:jenkins][:http_proxy][:host_aliases]         = []
+default[:jenkins][:http_proxy][:client_max_body_size] = "1024m"
+default[:jenkins][:http_proxy][:prefix]               = nil
+
 default[:jenkins][:server][:port] = 8080
 default[:jenkins][:server][:host] = node[:fqdn]
-default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}"
+if default[:jenkins][:http_proxy][:prefix]
+  default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}#{default[:jenkins][:http_proxy][:prefix]}"
+else
+  default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}"
+end
 
 default[:jenkins][:iptables_allow] = "enable"
 
@@ -113,10 +126,3 @@ default[:jenkins][:node][:ssh_pass] = nil
 default[:jenkins][:node][:jvm_options] = nil
 #jenkins master defaults to: "#{ENV['HOME']}/.ssh/id_rsa"
 default[:jenkins][:node][:ssh_private_key] = nil
-
-default[:jenkins][:http_proxy][:variant]              = nil
-default[:jenkins][:http_proxy][:www_redirect]         = "disable"
-default[:jenkins][:http_proxy][:listen_ports]         = [ 80 ]
-default[:jenkins][:http_proxy][:host_name]            = nil
-default[:jenkins][:http_proxy][:host_aliases]         = []
-default[:jenkins][:http_proxy][:client_max_body_size] = "1024m"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,22 +34,9 @@ else
   default[:jenkins][:server][:group] = node[:jenkins][:server][:user]
 end
 
-# HTTP Proxy
-default[:jenkins][:http_proxy][:variant]              = nil
-default[:jenkins][:http_proxy][:www_redirect]         = "disable"
-default[:jenkins][:http_proxy][:listen_ports]         = [ 80 ]
-default[:jenkins][:http_proxy][:host_name]            = nil
-default[:jenkins][:http_proxy][:host_aliases]         = []
-default[:jenkins][:http_proxy][:client_max_body_size] = "1024m"
-default[:jenkins][:http_proxy][:prefix]               = nil
-
 default[:jenkins][:server][:port] = 8080
 default[:jenkins][:server][:host] = node[:fqdn]
-if default[:jenkins][:http_proxy][:prefix]
-  default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}#{default[:jenkins][:http_proxy][:prefix]}"
-else
-  default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}"
-end
+default[:jenkins][:server][:url]  = "http://#{node[:jenkins][:server][:host]}:#{node[:jenkins][:server][:port]}#{node[:jenkins][:http_proxy][:prefix]}"
 
 default[:jenkins][:iptables_allow] = "enable"
 
@@ -126,3 +113,12 @@ default[:jenkins][:node][:ssh_pass] = nil
 default[:jenkins][:node][:jvm_options] = nil
 #jenkins master defaults to: "#{ENV['HOME']}/.ssh/id_rsa"
 default[:jenkins][:node][:ssh_private_key] = nil
+
+# HTTP Proxy
+default[:jenkins][:http_proxy][:variant]              = nil
+default[:jenkins][:http_proxy][:www_redirect]         = "disable"
+default[:jenkins][:http_proxy][:listen_ports]         = [ 80 ]
+default[:jenkins][:http_proxy][:host_name]            = nil
+default[:jenkins][:http_proxy][:host_aliases]         = []
+default[:jenkins][:http_proxy][:client_max_body_size] = "1024m"
+default[:jenkins][:http_proxy][:prefix]               = "/"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -82,39 +82,15 @@ case node.platform
 when "ubuntu", "debian"
   # See http://jenkins-ci.org/debian/
 
-  case node.platform
-  when "debian"
-    remote = "#{node[:jenkins][:mirror]}/latest/debian/jenkins.deb"
-    package_provider = Chef::Provider::Package::Dpkg
+  include_recipe "apt"
+  include_recipe "java"
 
-    package "daemon"
-    # These are both dependencies of the jenkins deb package
-    package "jamvm"
-    package "openjdk-6-jre"
-
-    package "psmisc"
-    key_url = "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
-
-    remote_file "#{tmp}/jenkins-ci.org.key" do
-      source "#{key_url}"
-    end
-
-    execute "add-jenkins-key" do
-      command "apt-key add #{tmp}/jenkins-ci.org.key"
-      action :nothing
-    end
-
-  when "ubuntu"
-    include_recipe "apt"
-    include_recipe "java"
-
-    apt_repository "jenkins" do
-      uri "http://pkg.jenkins-ci.org/debian"
-      distribution "binary/"
-      components [""]
-      key "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
-      action :add
-    end
+  apt_repository "jenkins" do
+    uri "http://pkg.jenkins-ci.org/debian"
+    distribution "binary/"
+    components [""]
+    key "http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key"
+    action :add
   end
 
   pid_file = "/var/run/jenkins/jenkins.pid"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -120,6 +120,13 @@ when "ubuntu", "debian"
   pid_file = "/var/run/jenkins/jenkins.pid"
   install_starts_service = true
 
+  template '/etc/default/jenkins' do
+    source 'etc-default-jenkins.erb'
+    owner 'root'
+    group 'root'
+    mode '0644'
+    notifies :restart, 'service[jenkins]'
+  end
 
 when "centos", "redhat"
   #see http://jenkins-ci.org/redhat/

--- a/templates/default/apache_jenkins.erb
+++ b/templates/default/apache_jenkins.erb
@@ -18,15 +18,16 @@
   ServerAlias       <%= a %>
 <% end -%>
 
+<% proxied_url = "http://localhost:#{node[:jenkins][:server][:port]}#{node[:jenkins][:http_proxy][:prefix]}" -%>
   # Local reverse proxy authorization override
   # Most unix distribution deny proxy by default
   # (ie /etc/apache2/mods-enabled/proxy.conf in Ubuntu)
-  <Proxy http://localhost:<%= node[:jenkins][:server][:port] %>/*>
+  <Proxy <%= proxied_url %>*>
     Order deny,allow
     Allow from all
   </Proxy>
 
   ProxyPreserveHost on
-  ProxyPass         /  http://localhost:<%= node[:jenkins][:server][:port] %>/
-  ProxyPassReverse  /  http://localhost:<%= node[:jenkins][:server][:port] %>/
+  ProxyPass         <%= node[:jenkins][:http_proxy][:prefix] %> <%= proxied_url %>
+  ProxyPassReverse  <%= node[:jenkins][:http_proxy][:prefix] %> <%= proxied_url %>
 </VirtualHost>

--- a/templates/default/etc-default-jenkins.erb
+++ b/templates/default/etc-default-jenkins.erb
@@ -1,0 +1,59 @@
+# defaults for jenkins continuous integration server
+
+# pulled in from the init script; makes things easier.
+NAME=jenkins
+
+# location of java
+JAVA=/usr/bin/java
+
+# arguments to pass to java
+#JAVA_ARGS="-Xmx256m"
+#JAVA_ARGS="-Djava.net.preferIPv4Stack=true" # make jenkins listen on IPv4 address
+
+PIDFILE=/var/run/jenkins/jenkins.pid
+
+# user id to be invoked as (otherwise will run as root; not wise!)
+JENKINS_USER=<%= node[:jenkins][:server][:user] %>
+
+# location of the jenkins war file
+JENKINS_WAR=/usr/share/jenkins/jenkins.war
+
+# jenkins home location
+JENKINS_HOME=<%= node[:jenkins][:server][:home] %>
+
+# set this to false if you don't want Hudson to run by itself
+# in this set up, you are expected to provide a servlet container
+# to host jenkins.
+RUN_STANDALONE=true
+
+# log location.  this may be a syslog facility.priority
+JENKINS_LOG=/var/log/jenkins/$NAME.log
+#HUDSON_LOG=daemon.info
+
+# OS LIMITS SETUP
+#   comment this out to observe /etc/security/limits.conf
+#   this is on by default because http://github.com/jenkinsci/jenkins/commit/2fb288474e980d0e7ff9c4a3b768874835a3e92e
+#   reported that Ubuntu's PAM configuration doesn't include pam_limits.so, and as a result the # of file
+#   descriptors are forced to 1024 regardless of /etc/security/limits.conf
+MAXOPENFILES=8192
+
+# port for HTTP connector (default 8080; disable with -1)
+HTTP_PORT=<%= node[:jenkins][:server][:port] %>
+
+# port for AJP connector (disabled by default)
+AJP_PORT=-1
+
+# servlet context, important if you want to use apache proxying
+PREFIX=<%= node[:jenkins][:http_proxy][:prefix] or '' %>
+
+# arguments to pass to jenkins.
+# --javahome=$JAVA_HOME
+# --httpPort=$HTTP_PORT (default 8080; disable with -1)
+# --httpsPort=$HTTP_PORT
+# --ajp13Port=$AJP_PORT
+# --argumentsRealm.passwd.$ADMIN_USER=[password]
+# --argumentsRealm.$ADMIN_USER=admin
+# --webroot=~/.jenkins/war
+# --prefix=$PREFIX
+
+JENKINS_ARGS="--webroot=/var/cache/jenkins/war --httpPort=$HTTP_PORT --ajp13Port=$AJP_PORT<%= node[:jenkins][:http_proxy][:prefix] ? ' --prefix=$PREFIX' : '' %>"


### PR DESCRIPTION
The running daemon reflects the JENKINS_HOME & HTTP Proxy Prefix values.
