### PR TITLE
dependency for ubuntu platform

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ license          "Apache 2.0"
 description      "Installs and configures Jenkins CI server & slaves"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.rdoc'))
 version          "0.5"
-%w(runit java iptables).each { |cb| depends cb }
+%w(apt runit java iptables).each { |cb| depends cb }


### PR DESCRIPTION
When I was trying to deploy default recipe at Ubuntu 12.04 I got error about missing apt cookbook. This commit solves this issue.
